### PR TITLE
Allow for conf-based control of auto-mounting glusterfs volume

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFileSystem.java
@@ -101,6 +101,7 @@ public class GlusterFileSystem extends FileSystem {
 		String volName = null;
 		String remoteGFSServer = null;
 		String needQuickRead = null;
+		boolean autoMount = true;
 
 		if (this.mounted)
 			return;
@@ -112,15 +113,18 @@ public class GlusterFileSystem extends FileSystem {
 			glusterMount = conf.get("fs.glusterfs.mount", null);
 			remoteGFSServer = conf.get("fs.glusterfs.server", null);
 			needQuickRead = conf.get("quick.slave.io", null);
+			autoMount = conf.getBoolean("fs.glusterfs.automount", true);
 
 			if ((volName.length() == 0) || (remoteGFSServer.length() == 0)
 					|| (glusterMount.length() == 0))
 				throw new RuntimeException("Not enough info to mount FUSE: volname="+volName + " glustermount=" + glusterMount);
 
-			
-			ret = FUSEMount(volName, remoteGFSServer, glusterMount);
-			if (!ret) {
-				throw new RuntimeException("Initialize: Failed to mount GlusterFS ");
+
+			if (autoMount) {
+				ret = FUSEMount(volName, remoteGFSServer, glusterMount);
+				if (!ret) {
+					throw new RuntimeException("Initialize: Failed to mount GlusterFS ");
+				}
 			}
 
 			if((needQuickRead.length() != 0)


### PR DESCRIPTION
Introduce a fs.glusterfs.automount configuration parameter, defaulting
to true, which when set to false will skip exec(mount ...) during
initialization.

Signed-off-by: Matthew Farrellee matt@redhat.com
