### PR TITLE
add mkdir tolerance tests

### DIFF
--- a/src/test/java/org/gluster/test/TestGluster.java
+++ b/src/test/java/org/gluster/test/TestGluster.java
@@ -134,6 +134,33 @@ public class TestGluster{
         gfs.initialize(temp.toURI(), conf);
 	}
     
+    
+    
+    @org.junit.Test
+    public void testTolerantMkdirs() throws Exception{
+        System.out.println("Testing tollerance of mkdirs(a/b/c/d) then mkdirs(a/b/c)");
+        Path longPath = new Path("a/b/c/d");
+        assertFalse(gfs.exists(longPath));
+        gfs.mkdirs(longPath);
+        assertTrue(gfs.exists(longPath));
+        gfs.mkdirs(new Path("a"));
+        assertTrue(gfs.exists(longPath));
+        assertTrue(gfs.exists(new Path("a")));
+        gfs.mkdirs(new Path("a/b"));
+        assertTrue(gfs.exists(longPath));
+        assertTrue(gfs.exists(new Path("a/b")));
+        gfs.mkdirs(new Path("a/b/c"));
+        assertTrue(gfs.exists(longPath));
+        assertTrue(gfs.exists(new Path("a/b/c")));
+        
+        /* delete the directories */
+        
+        gfs.delete(longPath);
+        assertFalse(gfs.exists(longPath));
+       
+        
+        
+    }
 	@org.junit.Test
 	public void testTextWriteAndRead() throws Exception{
 	   


### PR DESCRIPTION
here's some unit tests to verify the tolerance 
gfs.mkdirs("a/b/c/d") followed by gfs.mkdirs("a/b/c")
