### PR TITLE
fix to make mkdirs(..) tolerant of existing directories during a distrib...

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFileSystem.java
@@ -46,6 +46,13 @@ import java.util.TreeMap;
  * This package provides interface for hadoop jobs (incl. Map/Reduce)
  * to access files in GlusterFS backed file system via FUSE mount
  */
+
+
+/*
+ * 
+ * TODO: Evaluate LocalFileSystem and RawLocalFileSystem as possible delegate file systems to remove & refactor this code.
+ * 
+ */
 public class GlusterFileSystem extends FileSystem {
 
 	private FileSystem glusterFs = null;
@@ -180,6 +187,12 @@ public class GlusterFileSystem extends FileSystem {
 		return f.exists();
 	}
 
+	/*
+	 * Code copied from:
+	 * @see org.apache.hadoop.fs.RawLocalFileSystem#mkdirs(org.apache.hadoop.fs.Path)
+	 * as incremental fix towards a re-write. of this class to remove duplicity.
+	 * 
+	 */
 	public boolean mkdirs(Path f, FsPermission permission) throws IOException {
         
         if(f==null) return true;


### PR DESCRIPTION
The mkdirs(..) operation across the distributed file system may race other nodes during full path creation.  mkdirs(..) should not cause errors if directories or partial directory exists but instead continue the creation flow until the full path is created. 

This notion is documented in Cs RawLocalFileSystem source code as: "Creates the specified directory hierarchy. Does not treat existence as an error."  which is visible here:

http://grepcode.com/file/repository.cloudera.com/content/repositories/releases/com.cloudera.hadoop/hadoop-core/0.20.2-320/org/apache/hadoop/fs/RawLocalFileSystem.java#RawLocalFileSystem.mkdirs%28org.apache.hadoop.fs.Path%29

The mkdirs(..) patch logic is lifted from the same source.
