### PR TITLE
timestamp to jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.apache.hadoop.fs.glusterfs</groupId>
   <artifactId>glusterfs</artifactId>
   <packaging>jar</packaging>
-  <version>0.20.2-0.1</version>
+  <version>0.0.1-${maven.build.timestamp}</version>
   <name>glusterfs</name>
   <url>http://maven.apache.org</url>
   <dependencies>


### PR DESCRIPTION
Finally timestamped jars, version 1 - just a 0.0.1-TIMESTAMP.  

We can refine when we have perfected versioning scheme .  

Also would encourage anyone to edit this commit and i will fast track a +1, because anything with a timestamp is an improvement over the current jar nameing strategy.
