### PR TITLE
Configurable getfattr cmd, take 2

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFSXattr.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFSXattr.java
@@ -28,6 +28,7 @@ import java.util.TreeMap;
 import java.util.ArrayList;
 import java.util.Iterator;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 
 public class GlusterFSXattr{
@@ -42,7 +43,11 @@ public class GlusterFSXattr{
 
     private static String hostname;
 
-    public GlusterFSXattr(){
+   private String getFattrCmdBase;
+
+    public GlusterFSXattr(Configuration conf) {
+       getFattrCmdBase=conf.get("fs.glusterfs.getfattrcmd",
+                                  "getfattr -m . -n trusted.glusterfs.pathinfo");
     }
 
     public String brick2host(String brick) throws IOException{
@@ -135,7 +140,7 @@ public class GlusterFSXattr{
 
         HashMap<String, ArrayList<String>> vol=new HashMap<String, ArrayList<String>>();
 
-        getfattrCmd="getfattr -m . -n trusted.glusterfs.pathinfo "+filename;
+        getfattrCmd=this.getFattrCmdBase + " " + filename;
 
         p=Runtime.getRuntime().exec(getfattrCmd);
         brInput=new BufferedReader(new InputStreamReader(p.getInputStream()));

--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFileSystem.java
@@ -140,7 +140,7 @@ public class GlusterFileSystem extends FileSystem{
             this.workingDir=new Path(glusterMount);
             this.uri=URI.create(uri.getScheme()+"://"+uri.getAuthority());
 
-            this.xattr=new GlusterFSXattr();
+            this.xattr=new GlusterFSXattr(conf);
 
             InetAddress addr=InetAddress.getLocalHost();
             this.hostname=addr.getHostName();


### PR DESCRIPTION
This is a rebase of https://github.com/gluster/hadoop-glusterfs/pull/8 on top of current master (6d4b3877)

The code does the same thing, but the patches apply without merge conflicts and with the new code formatting guidelines, as applied by eclipse -nosplash -application org.eclipse.jdt.core.JavaCodeFormatter -verbose -config resources/eclipse-formatting-settings.xml
