### PR TITLE
test coverage auditing / automation via corbertura maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,26 @@
   </dependencies>
   <build>
     <plugins>
-      <plugin>
-		<groupId>org.apache.maven.plugins</groupId>
+ 	  <plugin>
+		  <groupId>org.codehaus.mojo</groupId>
+		  <artifactId>cobertura-maven-plugin</artifactId>
+		  <version>2.5.2</version>
+		  <configuration>
+			  <formats>
+				  <format>html</format>
+			  </formats>
+		  </configuration>
+		  <executions>
+			  <execution>
+				  <phase>package</phase>
+				  <goals>
+					  <goal>cobertura</goal>
+				  </goals>
+			  </execution>
+		  </executions>
+	  </plugin>
+          <plugin>
+	      <groupId>org.apache.maven.plugins</groupId>
 		<artifactId>maven-surefire-plugin</artifactId>
 		<configuration>
 			<!--  
@@ -73,7 +91,15 @@
         </configuration>
       </plugin>
       
-      
     </plugins>
   </build>
+  <reporting>
+	      <plugins>
+		            <plugin>
+				            <groupId>org.codehaus.mojo</groupId>
+					            <artifactId>cobertura-maven-plugin</artifactId>
+						            <version>2.5.2</version>
+							          </plugin>
+									    </plugins>
+									      </reporting>
 </project>


### PR DESCRIPTION
The following change generates an HTML report of test coverage that will be viewable on the build server i.e. 

ec2-54-243-59-213.compute-1.amazonaws.com:8080/job/glusterfs-hadoop-code-coverage/ws/target/site/cobertura/index.html
