### PR TITLE
GlusterFileSystemForTest -- a modular test class so that different hadoop tests can run against the same GFS implementation 

### DIFF
--- a/src/test/java/org/gluster/test/TestGluster.java
+++ b/src/test/java/org/gluster/test/TestGluster.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.glusterfs.GlusterFileSystem;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.tools.ant.util.FileUtils;
@@ -48,21 +49,19 @@ import org.junit.Test;
  * 
  */
 public class TestGluster{
-
     
-    static GlusterFileSystemForTest gfs ; 
+    static GlusterFileSystem gfs ; 
     
     @BeforeClass
     public static void setup() throws Exception {
-        gfs=new GlusterFileSystemForTest();
+        gfs= GFSUtil.create();
     }
     
     @AfterClass
     public static void after() throws IOException{
         gfs.close();
-        FileUtils.delete(gfs.getTempDirectory());
+        FileUtils.delete(GFSUtil.getTempDirectory());
     }
-    
 
     @org.junit.Test
     public void testTolerantMkdirs() throws Exception{


### PR DESCRIPTION
This pull request refactors our setup code from the original TestGluster class into a separate class.  The new GlusterFileSystemForTest can be used as the basis FileSystem implementation for other tests.  

This feature is necessary for the upcoming hadoop FileSystemBaseContract test implementation , which needs to swap in the FileSystem implementation as a class.
