### PR TITLE
Fix for testing rename to file that already exists.  Test not included (...

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFileSystem.java
@@ -468,6 +468,14 @@ public class GlusterFileSystem extends FileSystem{
         File fSrc=new File(absoluteSrc.toUri().getPath());
         File fDst=new File(absoluteDst.toUri().getPath());
 
+        /**
+         * Fix for bug uncovered by TestFileSystemBaseContract.testRenameFileAsExistingFile.
+         */
+        if(fDst.exists()){
+            log.info("Cannot rename " + src + " to " + dst + " : destination already exists.");
+            return false;
+        }
+            
         if(fDst.isDirectory()){
             fDst=null;
             String newPath=absoluteDst.toUri().getPath()+"/"+fSrc.getName();


### PR DESCRIPTION
Fixes behaviour on copying name over to existing destination .  Tests for this are in the FileSystemBaseContractTest.  
