### PR TITLE
pom update to fail fast when missing env variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,180 +1,191 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.hadoop.fs.glusterfs</groupId>
-  <artifactId>glusterfs</artifactId>
-  <packaging>jar</packaging>
-  <version>2.0-SNAPSHOT</version>
-  <name>glusterfs</name>
-  <url>http://maven.apache.org</url>
-  <dependencies>
-    <dependency>
-	<groupId>junit</groupId>
-		<artifactId>junit</artifactId>
-		<version>4.9</version>
-	   <scope>test</scope>
-	</dependency>
-    <dependency>
-        <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-common</artifactId>
-        <version>2.0.5-alpha</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common-test</artifactId>
-      <version>0.22.0</version>
-      <scope>test</scope>
-	</dependency>
-	<dependency>
-	   <groupId>org.apache.hadoop</groupId>
-	   <artifactId>hadoop-test</artifactId>
-	   <version>1.0.0</version>
-           <scope>test</scope>
-	</dependency>
-    <dependency>
-	    <groupId>org.slf4j</groupId>
-	    <artifactId>slf4j-api</artifactId>
-	    <version>1.5.8</version>
-    	<scope>compile</scope>
-	</dependency>
-	<dependency>	
-		<groupId>org.slf4j</groupId>
-		<artifactId>slf4j-log4j12</artifactId>
-		<version>1.7.3</version>
-	</dependency>
-  </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-		<groupId>org.apache.maven.plugins</groupId>
-		<artifactId>maven-surefire-plugin</artifactId>
-        <version>2.4.3</version>
-		<configuration>
-			<!--  
-				run "export GLUSTER_MOUNT=/mnt/glusterfs
-				     export HCFS_FILE_SYSTEM_CONNECTOR=org.gluster.test.GlusterFileSystemTestConnector
-				     export HCFS_CLASSNAME=org.apache.hadoop.fs.glusterfs.GlusterFileSystem" 
-			-->
-		    <systemProperties>
-				          <property>
-				             <name>GLUSTER_MOUNT</name>
-				             <value>${GLUSTER_MOUNT}</value>
-				          </property>
-				          <property>
-				             <name>HCFS_CLASSNAME</name>
-				             <value>${HCFS_CLASSNAME}</value>
-				          </property>
-				          <property>
-				             <name>HCFS_FILE_SYSTEM_CONNECTOR</name>
-				             <value>${HCFS_FILE_SYSTEM_CONNECTOR}</value>
-				          </property>
-				          
-			</systemProperties>
-		 </configuration>
- 	 </plugin>
-		      
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-        </configuration>
-      </plugin>
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.apache.hadoop.fs.glusterfs</groupId>
+	<artifactId>glusterfs</artifactId>
+	<packaging>jar</packaging>
+	<version>2.0-SNAPSHOT</version>
+	<name>glusterfs</name>
+	<url>http://maven.apache.org</url>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.9</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+			<version>2.0.5-alpha</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common-test</artifactId>
+			<version>0.22.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-test</artifactId>
+			<version>1.0.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.5.8</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>1.7.3</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.4.3</version>
+				<configuration>
+					<!-- run "export GLUSTER_MOUNT=/mnt/glusterfs export HCFS_FILE_SYSTEM_CONNECTOR=org.gluster.test.GlusterFileSystemTestConnector 
+						export HCFS_CLASSNAME=org.apache.hadoop.fs.glusterfs.GlusterFileSystem" -->
+					<systemProperties>
+						<property>
+							<name>GLUSTER_MOUNT</name>
+							<value>${GLUSTER_MOUNT}</value>
+						</property>
+						<property>
+							<name>HCFS_CLASSNAME</name>
+							<value>${HCFS_CLASSNAME}</value>
+						</property>
+						<property>
+							<name>HCFS_FILE_SYSTEM_CONNECTOR</name>
+							<value>${HCFS_FILE_SYSTEM_CONNECTOR}</value>
+						</property>
+					</systemProperties>
+				</configuration>
+			</plugin>
 
-<plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.1.4</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>revision</goal>
-                         </goals>
-                    </execution>
-                </executions>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<source>1.5</source>
+					<target>1.5</target>
+				</configuration>
+			</plugin>
 
-                <configuration>
-                    <!-- that's the default value, you don't have to set it -->
-                    <prefix>git</prefix>
+			<!-- Make sure that the HCFS properties are there  -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.2</version>
+				<executions>
+					<execution>
+						<id>enforce-hcfs-variables</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireProperty><property>HCFS_CLASSNAME</property></requireProperty>
+								<requireProperty><property>HCFS_FILE_SYSTEM_CONNECTOR</property></requireProperty>
+								<requireProperty><property>GLUSTER_MOUNT</property></requireProperty>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 
-                    <!-- that's the default value -->
-                    <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
+			<!-- Add Git Commit information as a properties file in the build. -->
+			<plugin>
+				<groupId>pl.project13.maven</groupId>
+				<artifactId>git-commit-id-plugin</artifactId>
+				<version>2.1.4</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+					</execution>
+				</executions>
 
-                    <!-- true is default here, it prints some more information during the build -->
-                    <verbose>true</verbose>
+				<configuration>
+					<!-- that's the default value, you don't have to set it -->
+					<prefix>git</prefix>
 
-                    <!--
-                        If you'd like to tell the plugin where your .git directory is,
-                        use this setting, otherwise we'll perform a search trying to
-                        figure out the right directory. It's better to add it explicite IMHO.
-                    -->
-                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+					<!-- that's the default value -->
+					<dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
 
-                    <!-- ALTERNATE SETUP - GENERATE FILE -->
-                    <!--
-                        If you want to keep git information, even in your WAR file etc,
-                        use this mode, which will generate a properties file (with filled out values)
-                        which you can then normally read using new Properties().load(/**/)
-                    -->
+					<!-- true is default here, it prints some more information during the 
+						build -->
+					<verbose>true</verbose>
 
-                    <!--
-                        this is true by default; You may want to set this to false, if the plugin should run inside a
-                        <packaging>pom</packaging> project. Most projects won't need to override this property.
+					<!-- If you'd like to tell the plugin where your .git directory is, 
+						use this setting, otherwise we'll perform a search trying to figure out the 
+						right directory. It's better to add it explicite IMHO. -->
+					<dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
 
-                        For an use-case for this kind of behaviour see: https://github.com/ktoso/maven-git-commit-id-plugin/issues/21
-                    -->
-                    <skipPoms>true</skipPoms>
+					<!-- ALTERNATE SETUP - GENERATE FILE -->
+					<!-- If you want to keep git information, even in your WAR file etc, 
+						use this mode, which will generate a properties file (with filled out values) 
+						which you can then normally read using new Properties().load(/**/) -->
 
-                    <!-- this is false by default, forces the plugin to generate the git.properties file -->
-                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+					<!-- this is true by default; You may want to set this to false, if 
+						the plugin should run inside a <packaging>pom</packaging> project. Most projects 
+						won't need to override this property. For an use-case for this kind of behaviour 
+						see: https://github.com/ktoso/maven-git-commit-id-plugin/issues/21 -->
+					<skipPoms>true</skipPoms>
 
-                    <!-- The path for the to be generated properties file, it's relative to ${project.basedir} -->
-                    <generateGitPropertiesFilename>src/main/resources/git.properties</generateGitPropertiesFilename>
+					<!-- this is false by default, forces the plugin to generate the git.properties 
+						file -->
+					<generateGitPropertiesFile>true</generateGitPropertiesFile>
 
-                    <!-- true by default, controls whether the plugin will fail when no .git directory is found, when set to false the plugin will just skip execution -->
-                    <!-- @since 2.0.4 -->
-                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+					<!-- The path for the to be generated properties file, it's relative 
+						to ${project.basedir} -->
+					<generateGitPropertiesFilename>src/main/resources/git.properties</generateGitPropertiesFilename>
 
-                    <!-- @since 2.1.0 -->
-                    <!-- 
-                        read up about git-describe on the in man, or it's homepage - it's a really powerful versioning helper 
-                        and the recommended way to use git-commit-id-plugin. The configuration bellow is optional, 
-                        by default describe will run "just like git-describe on the command line", even though it's a JGit reimplementation.
-                    -->
-                    <gitDescribe>
-                        <!-- This will show the available tags-->
+					<!-- true by default, controls whether the plugin will fail when no 
+						.git directory is found, when set to false the plugin will just skip execution -->
+					<!-- @since 2.0.4 -->
+					<failOnNoGitDirectory>false</failOnNoGitDirectory>
+
+					<!-- @since 2.1.0 -->
+					<!-- read up about git-describe on the in man, or it's homepage - it's 
+						a really powerful versioning helper and the recommended way to use git-commit-id-plugin. 
+						The configuration bellow is optional, by default describe will run "just 
+						like git-describe on the command line", even though it's a JGit reimplementation. -->
+					<gitDescribe>
+						<!-- This will show the available tags -->
 						<tags>true</tags>
-						
-                        <!-- don't generate the describe property -->
-                        <skip>false</skip>
-                        <!-- 
-                            if no tag was found "near" this commit, just print the commit's id instead, 
-                            helpful when you always expect this field to be not-empty 
-                        -->
-                        <always>false</always>
-                        <!--
-                             how many chars should be displayed as the commit object id? 
-                             7 is git's default, 
-                             0 has a special meaning (see end of this README.md), 
-                             and 40 is the maximum value here 
-                        -->
-                        <abbrev>7</abbrev>
 
-                        <!-- when the build is triggered while the repo is in "dirty state", append this suffix -->
-                        <dirty>-dirty</dirty>
+						<!-- don't generate the describe property -->
+						<skip>false</skip>
+						<!-- if no tag was found "near" this commit, just print the commit's 
+							id instead, helpful when you always expect this field to be not-empty -->
+						<always>false</always>
+						<!-- how many chars should be displayed as the commit object id? 7 
+							is git's default, 0 has a special meaning (see end of this README.md), and 
+							40 is the maximum value here -->
+						<abbrev>7</abbrev>
 
-                        <!-- 
-                             always print using the "tag-commits_from_tag-g_commit_id-maybe_dirty" format, even if "on" a tag. 
-                             The distance will always be 0 if you're "on" the tag. 
-                        -->
-                        <forceLongFormat>false</forceLongFormat>
-                    </gitDescribe>
-                </configuration>
+						<!-- when the build is triggered while the repo is in "dirty state", 
+							append this suffix -->
+						<dirty>-dirty</dirty>
 
-            </plugin>      
-      
-    </plugins>
-  </build>
+						<!-- always print using the "tag-commits_from_tag-g_commit_id-maybe_dirty" 
+							format, even if "on" a tag. The distance will always be 0 if you're "on" 
+							the tag. -->
+						<forceLongFormat>false</forceLongFormat>
+					</gitDescribe>
+				</configuration>
+
+			</plugin>
+
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
Added a plugin that validates all the ENV variables required for the new build.  
Otherwise test fail catastrophically (100s of failures), without a clear reason until you dig deeper.

<requireProperty><property>HCFS_CLASSNAME</property></requireProperty>
<requireProperty><property>HCFS_FILE_SYSTEM_CONNECTOR</property></requireProperty>
<requireProperty><property>GLUSTER_MOUNT</property></requireProperty>

FYI Also redid the formatting. 
