### PR TITLE
Buffering unit test: Confirms that we have a reasonable write buffer as ...

### DIFF
--- a/src/test/java/org/apache/hadoop/fs/test/unit/HcfsTestBufferingOperations.java
+++ b/src/test/java/org/apache/hadoop/fs/test/unit/HcfsTestBufferingOperations.java
@@ -25,7 +25,11 @@ public class HcfsTestBufferingOperations{
 
     @Test
     public void test() throws Exception {
-        FSDataOutputStream os = fSys.create(new Path("/a"));
+        Path out = new Path("a");
+        
+        System.out.println("Writing file to: "+out.makeQualified(fSys));
+        
+        FSDataOutputStream os = fSys.create(out);
         
         int written=0;
         /**
@@ -36,9 +40,11 @@ public class HcfsTestBufferingOperations{
             written+="ASDF".getBytes().length;
             //now, we expect
             System.out.println("Checking if "+ written +" bytes were spilled yet...");
-            Assert.assertTrue("asserting that file not written yet",fSys.getLength(new Path("/a"))==0);
+            Assert.assertTrue("asserting that file not written yet",fSys.getLength(out)==0);
         }
-        
+        os.flush();
+        Assert.assertTrue("asserting that file not written yet",fSys.getLength(out)>=10000);
+
         os.close();
     }
     


### PR DESCRIPTION
By testing the buffering at build time, we can gaurantee that our write buffering strategy is exceeding the 8k or 4k defaults which we've seen in hadoops RawLocalFileSystem.  

Otherwise, while we change our filesystem write implementations, we can regress in buffering functionality which is very costly.
