### PR TITLE
Working Directory patch to force hadoop < 1.2 to use /user/{user.name}/ ...

### DIFF
--- a/src/test/java/org/apache/hadoop/fs/test/unit/HCFSTestWorkingDir.java
+++ b/src/test/java/org/apache/hadoop/fs/test/unit/HCFSTestWorkingDir.java
@@ -1,0 +1,60 @@
+package org.apache.hadoop.fs.test.unit;
+
+import static org.apache.hadoop.fs.FileSystemTestHelper.getTestRootPath;
+
+import java.io.File;
+
+import junit.framework.Assert;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.test.connector.HcfsTestConnectorFactory;
+import org.apache.hadoop.fs.test.connector.HcfsTestConnectorInterface;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HCFSTestWorkingDir{
+
+    Logger log = LoggerFactory.getLogger(HCFSTestWorkingDir.class);
+    FileSystem fSys;
+
+    @Before
+    public void setUp() throws Exception{
+        HcfsTestConnectorInterface connector=
+                HcfsTestConnectorFactory.getHcfsTestConnector();
+        fSys=connector.create();
+    }
+
+    /**
+     * This test fails in hadoop 1.2.0, if we do not have
+     * logic in the GlusterVolume to use "getInitialWorkingDirectory" 
+     * as the starting working directory.  
+     */
+    @Test
+    public void test() throws Exception {
+        Path outpath = new Path("to_");
+        if(fSys.exists(outpath)){
+            fSys.delete(outpath,true);
+        }
+        File tmpfile = new File("/tmp/test_copyfromlocal");
+        tmpfile.createNewFile();
+        log.info(tmpfile.getAbsolutePath());
+        Assert.assertTrue(tmpfile.exists());
+        
+        fSys.copyFromLocalFile(false,  false, 
+                new Path(tmpfile.getPath()), 
+                outpath);
+     
+        Assert.assertTrue(fSys.exists(outpath));
+        fSys.delete(outpath,true);
+    }
+    
+    @After
+    public void tearDown() throws Exception{
+        fSys.delete(getTestRootPath(fSys, "test"), true);
+    }
+}


### PR DESCRIPTION
This fixes errors that occur with unqualified paths in a typical hadoop workflow, for example: 

"hadoop fs -put localfile dfsfile"

In the above command, hadoop 1.2 and earlier RawLocalFileSYStem implementations assume that the "user.dir" is the directory which unqualified files should go in.  

To prevent this behaviour, we now make sure that this initial working directory is set to the current working directory when any GlusterVolume based FileSystem is created. 
