### PR TITLE
2.1.6-SNAPSHOT (for 2.1.5 release) + spc.tmpl updates for RPM Releases.

### DIFF
--- a/glusterfs-hadoop.spec.tmpl
+++ b/glusterfs-hadoop.spec.tmpl
@@ -1,0 +1,63 @@
+Name: rhs-hadoop
+Version: $version
+Release: $release
+#if $epoch
+Epoch: $epoch
+#end if
+License: Apache
+Summary: GlusterFS Hadoop Plugin
+Group: Application/File
+
+#for $i, $artifact in $enumerate($all_artifacts)
+Source$i: $artifact
+#end for
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch: noarch
+
+# yes, this is /usr/lib even on 64-bit
+%global hadoop_libdir %{_prefix}/lib/hadoop/lib
+
+%description
+The Gluster Filesystem Hadoop implementation for both Hadoop 1.x and 2.x.  This
+Java plugin for Hadoop allows MapReduce and YARN to run on top of Gluster, by providing the
+GlusterFileSystem (1.x) and GlusterFs (2.x) implementations.  These should be referenced
+in the hadoop configuration files and loaded at runtime as the FileSystem implementation. 
+
+%prep
+
+%build
+
+%install
+rm -rf %{buildroot}
+/bin/mkdir -p %{buildroot}%{_javadir}
+/bin/mkdir -p %{buildroot}%{hadoop_libdir}
+
+#for $i, $artifact in $enumerate($all_artifacts)
+  #if $artifact.endswith('.jar')
+/usr/bin/install -m 644 %{SOURCE$i} %{buildroot}%{_javadir}
+/bin/ln -s ../../../..%{_javadir}/$artifact %{buildroot}%{hadoop_libdir}/$artifact
+  #end if
+#end for
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+#for $i, $artifact in $enumerate($all_artifacts)
+  #if $artifact.endswith('.jar')
+%{_javadir}/$artifact
+%{hadoop_libdir}/$artifact
+  #end if
+#end for
+
+%changelog
+* Wed Jan 9 2014 Jay Vyas <jvyas@redhat.com> 2.1.4 renamed
+- rename to rhs-hadoop for release
+
+* Fri Nov 22 2013 Jay Vyas <jvyas@rehdat.com> 2.1.4
+- Initial import into the glusterfs-hadoop plugin as part of our deployment. 
+
+* Fri May 18 2012 Anthony Towns <atowns@redhat.com> - 0.20.2-0
+- Initial build

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.apache.hadoop.fs.glusterfs</groupId>
   <artifactId>glusterfs</artifactId>
   <packaging>jar</packaging>
-  <version>2.0-SNAPSHOT</version>
+  <version>2.1.5-SNAPSHOT</version>
   <name>glusterfs</name>
   <url>http://maven.apache.org</url>
   <dependencies>


### PR DESCRIPTION
2.1.6-SNAPSHOT release patch.  This marks a change in the version naming, where we will update point releases into the maven pom, fork off of those releases to modify the pom.  TODO make 2.1.5-release tag ...........
