### PR TITLE
Remove automatic directory creation of mapred.system.dir

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterVolume.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterVolume.java
@@ -135,7 +135,9 @@ public class GlusterVolume extends RawLocalFileSystem{
                 }
                 
                 if(sameVolume(mapredSysDirectory) && !exists(mapredSysDirectory) ){
-                    mkdirs(mapredSysDirectory);
+                    //mkdirs(mapredSysDirectory);
+                   log.error("Exception loading glusterfs plugin.  mapred.system.dir defined as: " + mapredSysDirectory + " but does not exit.");
+                   throw new RuntimeException("mapred.system.dir: " + mapredSysDirectory + " does not exist.");
                 }
                 //Working directory setup
                 


### PR DESCRIPTION
The mapred.system.dir is required for map reduce jobs to run.  Up until now the SHIM creates the directory as a user convenience, but this isn't the best behavior and could lead to security problems.  The directory should be created before the user starts hadoop.

This patch removes the automatic directory creation and instead throws a Runtime exception.
