### PR TITLE
Fix for an exception when a non glusterfs URI is passed into the sameVolume code which has no scheme

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterVolume.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterVolume.java
@@ -95,10 +95,9 @@ public class GlusterVolume extends RawLocalFileSystem{
     public boolean sameVolume(Path p){
         URI thisUri = this.NAME;
         URI thatUri = p.toUri();
-        if(!thatUri.getScheme().equalsIgnoreCase(thisUri.getScheme())) return false;
-        if((thatUri.getAuthority()==null && thisUri.getAuthority()==null)) return true;
+        if(!thisUri.getScheme().equalsIgnoreCase(thatUri.getScheme())) return false;
+        if((thisUri.getAuthority()==null && thatUri.getAuthority()==null)) return true;
         return (thatUri.getAuthority()!=null && thatUri.getAuthority().equalsIgnoreCase(thisUri.getAuthority()));
-        
     }
     
     public void setConf(Configuration conf){


### PR DESCRIPTION
If the mapreduce.jobtracker.system.dir property is undefined, then mapred-site-default.xml is loaded from JAR which set the value to /tmp/hadop/something

this value is eventually checked in sameVolume, and since there is no scheme the check throws an NPE.  this pull is a fix for that.
