### PR TITLE
Refactor and cleanup the BlockLocation parsing code

### DIFF
--- a/conf/core-site.xml
+++ b/conf/core-site.xml
@@ -44,9 +44,9 @@
 		<value>gv0,gv1</value>
 	</property>
 	
-	<property>
+    <property>
 		<name>fs.glusterfs.volume.fuse.gv0</name>
-		<value>/mnt/gv0</value>
+		<value>/mnt/glusterfs/glustertest</value>
 	</property>
 	
 	<property>

--- a/conf/core-site.xml
+++ b/conf/core-site.xml
@@ -44,9 +44,9 @@
 		<value>gv0,gv1</value>
 	</property>
 	
-    <property>
+	<property>
 		<name>fs.glusterfs.volume.fuse.gv0</name>
-		<value>/mnt/glusterfs/glustertest</value>
+		<value>/mnt/gv0</value>
 	</property>
 	
 	<property>

--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFSXattr.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFSXattr.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.fs.glusterfs;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
@@ -29,434 +30,88 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.RegEx;
+
 import org.apache.hadoop.fs.BlockLocation;
 
 public class GlusterFSXattr{
 
-    public enum LAYOUT {
-        D, S, R, DS, DR, SR, DSR
-    }
-
-    public enum CMD {
-        GET_HINTS, GET_REPLICATION, GET_BLOCK_SIZE, CHECK_FOR_QUICK_IO
-    }
-
-    private static String hostname;
-
    private String getFattrCmdBase = null;
+   private String filename = null;
+   private String xattrValue = null;
    
-   public GlusterFSXattr(String getAttr) {
-       getFattrCmdBase=getAttr;
+   public GlusterFSXattr(String fileName) {
+      this(fileName,  "sudo getfattr -m . -n trusted.glusterfs.pathinfo");
    }
   
-   public GlusterFSXattr(){
-	   getFattrCmdBase = "sudo getfattr -m . -n trusted.glusterfs.pathinfo";
+   public GlusterFSXattr(String fileName, String getAttr){
+	   getFattrCmdBase=getAttr;
+	   this.filename = fileName;
+   }
+    
+   public void reset(){
+	   xattrValue=null;  
    }
    
-    public String brick2host(String brick) throws IOException{
-        String[] hf=null;
+   public static String shellToString(String shellCommand) throws IOException{
+	 
+       Process p=Runtime.getRuntime().exec(shellCommand);
+       BufferedReader brInput=null;
+       String s=null;
+       
+       brInput=new BufferedReader(new InputStreamReader(p.getInputStream()));
 
-        hf=brick.split(":");
-        if(hf.length!=2){
-            System.out.println("brick not of format hostname:path");
-            throw new IOException("Error getting hostname from brick");
-        }
-
-        return hf[0];
+       String value="";
+       while ((s=brInput.readLine())!=null)
+       	value+=s;
+       
+       return value;
+   }
+   
+    /* Caches the xattr value.  Must call reset() to re-query */
+    public String execGetFattr() throws IOException{
+    	if(xattrValue==null){
+	        xattrValue=shellToString(this.getFattrCmdBase + " " + filename);
+	        
+	        /* strip off 'trusted.glusterfs.pathinfo="  and the last quote*/
+	    	xattrValue = xattrValue.substring(28,xattrValue.length()-1);
+    	}
+       
+    	return xattrValue;
     }
 
-    public String brick2file(String brick) throws IOException{
-        String[] hf=null;
-
-        hf=brick.split(":");
-        if(hf.length!=2){
-            System.out.println("brick not of format hostname:path");
-            throw new IOException("Error getting hostname from brick");
-        }
-
-        return hf[1];
-    }
-
-    public BlockLocation[] getPathInfo(String filename,long start,long len) throws IOException{
-        HashMap<String, ArrayList<String>> vol=null;
-        HashMap<String, Integer> meta=new HashMap<String, Integer>();
-
-        vol=execGetFattr(filename, meta, CMD.GET_HINTS);
-
-        return getHints(vol, meta, start, len, null);
-    }
-
-    public long getBlockSize(String filename) throws IOException{
-        HashMap<String, ArrayList<String>> vol=null;
-        HashMap<String, Integer> meta=new HashMap<String, Integer>();
-
-        vol=execGetFattr(filename, meta, CMD.GET_BLOCK_SIZE);
-
-        if(!meta.containsKey("block-size"))
-            return 0;
-
-        return (long) meta.get("block-size");
-
-    }
-
-    public short getReplication(String filename) throws IOException{
-        HashMap<String, ArrayList<String>> vol=null;
-        HashMap<String, Integer> meta=new HashMap<String, Integer>();
-
-        vol=execGetFattr(filename, meta, CMD.GET_REPLICATION);
-
-        return (short) getReplicationFromLayout(vol, meta);
-
-    }
-
-    public TreeMap<Integer, GlusterFSBrickClass> quickIOPossible(String filename,long start,long len) throws IOException{
-        String realpath=null;
-        HashMap<String, ArrayList<String>> vol=null;
-        HashMap<String, Integer> meta=new HashMap<String, Integer>();
-        TreeMap<Integer, GlusterFSBrickClass> hnts=new TreeMap<Integer, GlusterFSBrickClass>();
-
-        vol=execGetFattr(filename, meta, CMD.GET_HINTS);
-        getHints(vol, meta, start, len, hnts);
-
-        if(hnts.size()==0)
-            return null; // BOOM !!
-
-        // DEBUG - dump hnts here
-        return hnts;
-    }
-
-    public HashMap<String, ArrayList<String>> execGetFattr(String filename,HashMap<String, Integer> meta,CMD cmd) throws IOException{
-        Process p=null;
-        BufferedReader brInput=null;
-        String s=null;
-        String cmdOut=null;
-        String getfattrCmd=null;
-        String xlator=null;
-        String enclosingXl=null;
-        String enclosingXlVol=null;
-        String key=null;
-        String layout="";
-        int rcount=0;
-        int scount=0;
-        int dcount=0;
-        int count=0;
-
-        HashMap<String, ArrayList<String>> vol=new HashMap<String, ArrayList<String>>();
-
-        getfattrCmd=this.getFattrCmdBase + " " + filename;
-
-        p=Runtime.getRuntime().exec(getfattrCmd);
-        brInput=new BufferedReader(new InputStreamReader(p.getInputStream()));
-
-        cmdOut="";
-        while ((s=brInput.readLine())!=null)
-            cmdOut+=s;
-
-        /**
-         * TODO: Use a single regex for extracting posix paths as well as xlator
-         * counts for layout matching.
-         */
-
-        Pattern pattern=Pattern.compile("<(.*?)[:\\(](.*?)>");
-        Matcher matcher=pattern.matcher(cmdOut);
-
-        Pattern p_px=Pattern.compile(".*?:(.*)");
-        Matcher m_px;
-        String gibberish_path;
-
-        s=null;
-        while (matcher.find()){
-            xlator=matcher.group(1);
-            if(xlator.equalsIgnoreCase("posix")){
-                if(enclosingXl.equalsIgnoreCase("replicate"))
-                    count=rcount;
-                else if(enclosingXl.equalsIgnoreCase("stripe"))
-                    count=scount;
-                else if(enclosingXl.equalsIgnoreCase("distribute"))
-                    count=dcount;
-                else
-                    throw new IOException("Unknown Translator: "+enclosingXl);
-
-                key=enclosingXl+"-"+count;
-
-                if(vol.get(key)==null)
-                    vol.put(key, new ArrayList<String>());
-
-                gibberish_path=matcher.group(2);
-
-                /* extract posix path from the gibberish string */
-                m_px=p_px.matcher(gibberish_path);
-                if(!m_px.find())
-                    throw new IOException("Cannot extract posix path");
-
-                vol.get(key).add(m_px.group(1));
-                continue;
-            }
-
-            enclosingXl=xlator;
-            enclosingXlVol=matcher.group(2);
-
-            if(xlator.equalsIgnoreCase("replicate"))
-                if(rcount++!=0)
-                    continue;
-
-            if(xlator.equalsIgnoreCase("stripe")){
-                if(scount++!=0)
-                    continue;
-
-                Pattern ps=Pattern.compile("\\[(\\d+)\\]");
-                Matcher ms=ps.matcher(enclosingXlVol);
-
-                if(ms.find()){
-                    if(((cmd==CMD.GET_BLOCK_SIZE)||(cmd==CMD.GET_HINTS))&&(meta!=null))
-                        meta.put("block-size", Integer.parseInt(ms.group(1)));
-                }else
-                    throw new IOException("Cannot get stripe size");
-            }
-
-            if(xlator.equalsIgnoreCase("distribute"))
-                if(dcount++!=0)
-                    continue;
-
-            layout+=xlator.substring(0, 1);
-        }
-
-        if((dcount==0)&&(scount==0)&&(rcount==0))
-            throw new IOException("Cannot get layout");
-
-        if(meta!=null){
-            meta.put("dcount", dcount);
-            meta.put("scount", scount);
-            meta.put("rcount", rcount);
-        }
-
-        vol.put("layout", new ArrayList<String>(1));
-        vol.get("layout").add(layout);
-
-        return vol;
-    }
-
-    BlockLocation[] getHints(HashMap<String, ArrayList<String>> vol,HashMap<String, Integer> meta,long start,long len,TreeMap<Integer, GlusterFSBrickClass> hnts) throws IOException{
-        String brick=null;
-        String key=null;
-        boolean done=false;
-        int i=0;
-        int counter=0;
-        int stripeSize=0;
-        long stripeStart=0;
-        long stripeEnd=0;
-        int nrAllocs=0;
-        int allocCtr=0;
-        BlockLocation[] result=null;
-        ArrayList<String> brickList=null;
-        ArrayList<String> stripedBricks=null;
-        Iterator<String> it=null;
-
-        String[] blks=null;
-        GlusterFSBrickRepl[] repl=null;
-        int dcount,scount,rcount;
-
-        LAYOUT l=LAYOUT.valueOf(vol.get("layout").get(0));
-        dcount=meta.get("dcount");
-        scount=meta.get("scount");
-        rcount=meta.get("rcount");
-
-        switch (l){
-            case D:
-                key="DISTRIBUTE-"+dcount;
-                brick=vol.get(key).get(0);
-
-                if(hnts==null){
-                    result=new BlockLocation[1];
-                    result[0]=new BlockLocation(null, new String[]{brick2host(brick)}, start, len);
-                }else
-                    hnts.put(0, new GlusterFSBrickClass(brick, start, len, false, -1, -1, -1));
-                break;
-
-            case R:
-            case DR:
-                /* just the name says it's striped - the volume isn't */
-                stripedBricks=new ArrayList<String>();
-
-                for(i=1;i<=rcount;i++){
-                    key="REPLICATE-"+i;
-                    brickList=vol.get(key);
-                    it=brickList.iterator();
-                    while (it.hasNext()){
-                        stripedBricks.add(it.next());
-                    }
-                }
-
-                nrAllocs=stripedBricks.size();
-                if(hnts==null){
-                    result=new BlockLocation[1];
-                    blks=new String[nrAllocs];
-                }
-
-                for(i=0;i<nrAllocs;i++){
-                    if(hnts==null)
-                        blks[i]=brick2host(stripedBricks.get(i));
-                    else
-                        hnts.put(i, new GlusterFSBrickClass(stripedBricks.get(i), start, len, false, -1, -1, -1));
-                }
-
-                if(hnts==null)
-                    result[0]=new BlockLocation(null, blks, start, len);
-
-                break;
-
-            case SR:
-            case DSR:
-                int rsize=0;
-                ArrayList<ArrayList<String>> replicas=new ArrayList<ArrayList<String>>();
-
-                stripedBricks=new ArrayList<String>();
-
-                if(rcount==0)
-                    throw new IOException("got replicated volume with replication count 0");
-
-                for(i=1;i<=rcount;i++){
-                    key="REPLICATE-"+i;
-                    brickList=vol.get(key);
-                    it=brickList.iterator();
-                    replicas.add(i-1, new ArrayList<String>());
-                    while (it.hasNext()){
-                        replicas.get(i-1).add(it.next());
-                    }
-                }
-
-                stripeSize=meta.get("block-size");
-
-                nrAllocs=(int) (((len-start)/stripeSize)+1);
-                if(hnts==null){
-                    result=new BlockLocation[nrAllocs];
-                    repl=new GlusterFSBrickRepl[nrAllocs];
-                }
-
-                // starting stripe position
-                counter=(int) ((start/stripeSize)%rcount);
-                stripeStart=start;
-
-                key=null;
-                int currAlloc=0;
-                boolean hntsDone=false;
-                while ((stripeStart<len)&&!done){
-                    stripeEnd=(stripeStart-(stripeStart%stripeSize))+stripeSize-1;
-                    if(stripeEnd>start+len){
-                        stripeEnd=start+len-1;
-                        done=true;
-                    }
-
-                    rsize=replicas.get(counter).size();
-
-                    if(hnts==null)
-                        repl[allocCtr]=new GlusterFSBrickRepl(rsize, stripeStart, (stripeEnd-stripeStart));
-
-                    for(i=0;i<rsize;i++){
-                        brick=replicas.get(counter).get(i);
-                        currAlloc=(allocCtr*rsize)+i;
-
-                        if(hnts==null)
-                            repl[allocCtr].addHost(brick2host(brick));
-                        else if(currAlloc<=(rsize*rcount)-1){
-                            hnts.put(currAlloc, new GlusterFSBrickClass(brick, stripeStart, (stripeEnd-stripeStart), true, stripeSize, rcount, rsize));
-                        }else
-                            hntsDone=true;
-                    }
-
-                    if(hntsDone)
-                        break;
-
-                    stripeStart=stripeEnd+1;
-
-                    allocCtr++;
-                    counter++;
-
-                    if(counter>=replicas.size())
-                        counter=0;
-                }
-
-                if(hnts==null)
-                    for(int k=0;k<nrAllocs;k++)
-                        result[k]=new BlockLocation(null, repl[k].getReplHosts(), repl[k].getStartLen(), repl[k].getOffLen());
-
-                break;
-
-            case S:
-            case DS:
-                if(scount==0)
-                    throw new IOException("got striped volume with stripe count 0");
-
-                stripedBricks=new ArrayList<String>();
-                stripeSize=meta.get("block-size");
-
-                key="STRIPE-"+scount;
-                brickList=vol.get(key);
-                it=brickList.iterator();
-                while (it.hasNext()){
-                    stripedBricks.add(it.next());
-                }
-
-                nrAllocs=(int) ((len-start)/stripeSize)+1;
-                if(hnts==null)
-                    result=new BlockLocation[nrAllocs];
-
-                // starting stripe position
-                counter=(int) ((start/stripeSize)%stripedBricks.size());
-                stripeStart=start;
-
-                key=null;
-                while ((stripeStart<len)&&!done){
-                    brick=stripedBricks.get(counter);
-
-                    stripeEnd=(stripeStart-(stripeStart%stripeSize))+stripeSize-1;
-                    if(stripeEnd>start+len){
-                        stripeEnd=start+len-1;
-                        done=true;
-                    }
-
-                    if(hnts==null)
-                        result[allocCtr]=new BlockLocation(null, new String[]{brick2host(brick)}, stripeStart, (stripeEnd-stripeStart));
-                    else if(allocCtr<=stripedBricks.size()){
-                        hnts.put(allocCtr, new GlusterFSBrickClass(brick, stripeStart, (stripeEnd-stripeStart), true, stripeSize, stripedBricks.size(), -1));
-                    }else
-                        break;
-
-                    stripeStart=stripeEnd+1;
-
-                    counter++;
-                    allocCtr++;
-
-                    if(counter>=stripedBricks.size())
-                        counter=0;
-                }
-
-                break;
-        }
-
-        return result;
-    }
-
-    /* TODO: use meta{dcount,scount,rcount} for checking */
-    public int getReplicationFromLayout(HashMap<String, ArrayList<String>> vol,HashMap<String, Integer> meta) throws IOException{
-        int replication=0;
-        LAYOUT l=LAYOUT.valueOf(vol.get("layout").get(0));
-
-        switch (l){
-            case D:
-            case S:
-            case DS:
-                replication=1;
-                break;
-
-            case R:
-            case DR:
-            case SR:
-            case DSR:
-                final String key="REPLICATION-1";
-                replication=vol.get(key).size();
-        }
-
-        return replication;
-    }
+    
+    
+	public BlockLocation[] getPathInfo(long start, long len) {
+		String xattr = null;
+		//Pattern blockReg = Pattern.compile("<POSIX([^)]*):([^:]*)");
+		Pattern blockReg = Pattern.compile("<POSIX(.*):((.*)):");
+		ArrayList<BlockLocation> blockLocations = new ArrayList<BlockLocation>();
+		try {
+			xattr = execGetFattr();
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		Matcher matcher = blockReg.matcher(xattr);
+		ArrayList<String> list = new ArrayList<String>();
+		while(matcher.find()){
+			String host = matcher.group(2);
+			list.add(host);
+			/*
+			for(int i=0;i<matcher.groupCount();i++)
+		    	System.out.println(matcher.group(i));
+			*/
+		}
+		String hosts[] = list.toArray(new String[list.size()]);
+		BlockLocation b = new BlockLocation(null, hosts, start, len);
+		b.setCachedHosts(hosts);
+		blockLocations.add(b);
+
+		return blockLocations.toArray(new BlockLocation[blockLocations.size()]);
+	}
+
+
+    
 }

--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFileStatus.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFileStatus.java
@@ -56,6 +56,10 @@ public class GlusterFileStatus extends FileStatus{
         this.fs=fs;
     }
 
+    GlusterFileStatus(File f, GlusterVolume fs){
+       this(f,f.length(),fs);
+    }
+    
     @Override
     public FsPermission getPermission(){
         if(!isPermissionLoaded()){

--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterVolume.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterVolume.java
@@ -355,22 +355,14 @@ public class GlusterVolume extends RawLocalFileSystem{
         }
         
         if (path.exists()) {
-          return new GlusterFileStatus(pathToFile(f), getBlockSize(f), this);
+          return new GlusterFileStatus(pathToFile(f), this);
         } else {
           throw new FileNotFoundException( "File " + f + " does not exist.");
         }
       }
     
     public long getBlockSize(Path path) throws IOException{
-        long blkSz;
-        File f=pathToFile(path);
-        String blockSize = GlusterFSXattr.shellToString("stat --format=%o " + f.getAbsolutePath().toString());
-        long blocksize =  Long.parseLong(blockSize);
-        
-        if(blocksize < 1){
-        	return getDefaultBlockSize();
-        }
-        return blocksize ; 
+    	return getLength(path);
     }
     
     public void setOwner(Path p, String username, String groupname)
@@ -386,14 +378,11 @@ public class GlusterVolume extends RawLocalFileSystem{
 
     public BlockLocation[] getFileBlockLocations(FileStatus file,long start,long len) throws IOException{
         File f=pathToFile(file.getPath());
-        BlockLocation[] result=null;
-
-        result=new GlusterFSXattr(f.getPath()).getPathInfo(start, len);
+        BlockLocation[] result = new GlusterFSXattr(f.getPath()).getPathInfo(start, len);
         if(result==null){
-            log.info("Problem getting destination host for file "+f.getPath());
-            return null;
+            log.info("GLUSTERFS: Problem getting host/block location for file "+f.getPath());
         }
-
+        
         return result;
     }
     

--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterVolume.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterVolume.java
@@ -289,10 +289,14 @@ public class GlusterVolume extends RawLocalFileSystem{
 	}
 	
 	public boolean mkdirs(Path f) throws IOException {
-		if(f != null) f = f.makeQualified(this);
-	    return super.mkdirs(f);
+	      if(f == null) {
+	        throw new IllegalArgumentException("mkdirs path arg is null");
+	      }
+	      
+	      f = f.makeQualified(this);
+	      
+	      return super.mkdirs(f);
 	}
-	 
 	  
 	public FileStatus[] listStatus(Path f) throws IOException {
         File localf = pathToFile(f);
@@ -304,7 +308,7 @@ public class GlusterVolume extends RawLocalFileSystem{
         }
         if (localf.isFile()) {
           return new FileStatus[] {
-            new GlusterFileStatus(localf, getBlockSize(f), this) };
+            new GlusterFileStatus(localf, getDefaultBlockSize(), this) };
         }
         
         if(localf.isDirectory() && !localf.canRead()){
@@ -355,7 +359,7 @@ public class GlusterVolume extends RawLocalFileSystem{
         }
         
         if (path.exists()) {
-          return new GlusterFileStatus(pathToFile(f), this);
+          return new GlusterFileStatus(pathToFile(f), getDefaultBlockSize(), this);
         } else {
           throw new FileNotFoundException( "File " + f + " does not exist.");
         }

--- a/src/test/java/org/apache/hadoop/fs/test/TestBlockLocation.java
+++ b/src/test/java/org/apache/hadoop/fs/test/TestBlockLocation.java
@@ -1,0 +1,102 @@
+package org.apache.hadoop.fs.test;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.glusterfs.GlusterFSXattr;
+import org.apache.hadoop.fs.test.connector.HcfsTestConnectorFactory;
+import org.apache.hadoop.fs.test.connector.HcfsTestConnectorInterface;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestBlockLocation {
+
+	/*
+	 * Test subclass to simulate / inject xattr values instead of requiring
+	 * filesystem.
+	 * 
+	 */
+	class TestBlockLocationHarnace extends GlusterFSXattr {
+		String xattrValue = null;
+
+		TestBlockLocationHarnace(String xattrValue) {
+			super(null);
+			this.xattrValue = xattrValue;
+		}
+
+		public String execGetFattr() throws IOException {
+			return this.xattrValue;
+		}
+	}
+
+	@Test
+	public void testReplicateVolume() throws IOException {
+		String xattr = "trusted.glusterfs.pathinfo=\"(<DISTRIBUTE:StripeVolume-dht> (<STRIPE:StripeVolume-stripe-0:[131072]> <POSIX(/mnt/brick1/stripeVol):vm-1:/mnt/brick1/stripeVol/a>)\"";
+		xattr = xattr.substring(28, xattr.length() - 1);
+		TestBlockLocationHarnace tbl = new TestBlockLocationHarnace(xattr);
+
+		int start = 0;
+		int len = 0;
+		BlockLocation[] blocks = tbl.getPathInfo(start, len);
+		assertTrue(blocks.length == 1);
+		assertTrue(blocks[0].getHosts()[0].equals("vm-1"));
+	}
+
+	@Test
+	public void testReplicateVolume2() throws IOException {
+		String xattr = "trusted.glusterfs.pathinfo=\"(<DISTRIBUTE:HadoopVol-dht> (<REPLICATE:HadoopVol-replicate-0> <POSIX(/mnt/brick1/HadoopVol):vm-2:/mnt/brick1/HadoopVol/tmp/a> <POSIX(/mnt/brick1/HadoopVol):vm-1:/mnt/brick1/HadoopVol/tmp/a>))\"";
+		xattr = xattr.substring(28, xattr.length() - 1);
+		TestBlockLocationHarnace tbl = new TestBlockLocationHarnace(xattr);
+		BlockLocation[] blocks = tbl.getPathInfo(0, 10000);
+		
+		assertTrue(blocks.length == 1);
+		String hosts[] = blocks[0].getHosts();
+		
+		assertTrue(hosts[0].equals("vm-2"));
+		assertTrue(hosts[1].equals("vm-1"));
+	}
+
+	/*
+	 * Make sure the xattr code fails gracefull when the input is garbage.
+	 */
+	@Test
+	public void testFailureVolumeGarbage() {
+		String xattr = "dsfsffsfdsf";
+		TestBlockLocationHarnace tbl = new TestBlockLocationHarnace(xattr);
+		BlockLocation[] blocks = tbl.getPathInfo(0, 10000);
+		assertNull(blocks);
+	}
+
+	/*
+	 * Make sure the xattr code fails gracefully when the input is empty.
+	 */
+
+	@Test
+	public void testFailureVolumeEmpty() {
+		String xattr = "";
+		TestBlockLocationHarnace tbl = new TestBlockLocationHarnace(xattr);
+		BlockLocation[] blocks = tbl.getPathInfo(0, 10000);
+		assertNull(blocks);
+	}
+
+	/*
+	 * 
+	 * stripe not yet supported.trusted.pathinfo is incorrect in gluster:
+	 * https://bugzilla.redhat.com/show_bug.cgi?id=1200914
+	 */
+
+	public void testStripeVolume() {
+		String xattr = "trusted.glusterfs.pathinfo=\"(<DISTRIBUTE:yuck-dht> (<STRIPE:yuck-stripe-0:[131072]> (<REPLICATE:yuck-replicate-0> <POSIX(/tmp/yuck_brick1):questor:/tmp/yuck_brick1/testfile> <POSIX(/tmp/yuck_brick2):questor:/tmp/yuck_brick2/testfile>)(<REPLICATE:yuck-replicate-1> <POSIX(/tmp/yuck_brick3):questor:/tmp/yuck_brick3/testfile> <POSIX(/tmp/yuck_brick4):questor:/tmp/yuck_brick4/testfile>)(<REPLICATE:yuck-replicate-2> <POSIX(/tmp/yuck_brick5):questor:/tmp/yuck_brick5/testfile> <POSIX(/tmp/yuck_brick6):questor:/tmp/yuck_brick6/testfile>))\"";
+		;
+		xattr = xattr.substring(28, xattr.length() - 1);
+		TestBlockLocationHarnace tbl = new TestBlockLocationHarnace(xattr);
+		BlockLocation[] blocks = tbl.getPathInfo(0, 10000);
+
+	}
+
+}


### PR DESCRIPTION
This change cleans up the getfattr parsing.  It replaces a 2 pass regex rake with a simple single pass regex and removes the un-used code.

The previous 2-step rake was for a stripe feature which is broken upstream:
https://bugzilla.redhat.com/show_bug.cgi?id=1200914

The new code is fault tolerant and will not throw an error if the block information is unreadable. This will permit jobs to run regardless of Gluster volume configuration.