### PR TITLE
This change chops a configurable amount from the least significant digit...

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFileStatus.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFileStatus.java
@@ -52,7 +52,7 @@ public class GlusterFileStatus extends FileStatus{
      * This constructor is the only difference than the RawLocalFileStatus impl. RawLocalFileSystem converts a raw file path to path with the same prefix. ends up with a double /mnt/glusterfs.
      */
     GlusterFileStatus(File f, long defaultBlockSize, GlusterVolume fs){
-        super(f.length(), f.isDirectory(), 1, defaultBlockSize, f.lastModified(), fs.fileToPath(f));
+        super(f.length(), f.isDirectory(), 1, defaultBlockSize, fs.trimTimestamp(f.lastModified()), fs.fileToPath(f));
         this.fs=fs;
     }
 

--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterVolume.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterVolume.java
@@ -60,6 +60,7 @@ public class GlusterVolume extends RawLocalFileSystem{
     protected Hashtable<String,String> volumes=new Hashtable<String,String>();
     protected String default_volume = null;
     protected boolean sortDirectoryListing = false;
+    protected int tsPrecisionChop;
     
     protected static GlusterFSXattr attr = null;
     
@@ -195,12 +196,31 @@ public class GlusterVolume extends RawLocalFileSystem{
                 
                 log.info("Directory list order : " + (sortDirectoryListing?"sorted":"fs ordering")) ;
                 
+                /* 
+                 * Chops the specified number of least-significant-digits from the timestamp.
+                 * This will help on systems where clock-skew is higher than it should be.
+                 * 
+                 */
+                
+                tsPrecisionChop=conf.getInt("fs.glusterfs.timestamp.trim", 0);
+                log.info("File timestamp lease significant digits removed : " + tsPrecisionChop) ;
+                
             }
             catch (Exception e){
                 throw new RuntimeException(e);
             }
         }
+    }
         
+    
+ 
+    /* 
+     * truncates the least significant digits of a timestamp. 
+     * 
+     * */
+    public long trimTimestamp(long ts){
+    	long divide = ((long)Math.pow(10, tsPrecisionChop));
+    	return (long) ( (ts / divide)  * divide) ; 
     }
     
     public File pathToFile(Path path) {

--- a/src/test/java/org/apache/hadoop/fs/test/TimestampPrecision.java
+++ b/src/test/java/org/apache/hadoop/fs/test/TimestampPrecision.java
@@ -1,0 +1,67 @@
+package org.apache.hadoop.fs.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.glusterfs.GlusterVolume;
+import org.junit.Test;
+
+public class TimestampPrecision {
+
+	@Test
+	public void testSimpleTruncate0() throws IOException, URISyntaxException{
+		Configuration config = new Configuration();
+		config.setInt("fs.glusterfs.timestamp.trim", 0);
+		GlusterVolume fs = new GlusterVolume();
+		fs.initialize(new URI("glusterfs:///"), config);
+		
+		long value1 = 999911111;
+		long trim = fs.trimTimestamp(value1);
+		assertEquals(trim,value1);
+		
+	}
+	
+	
+	@Test
+	public void testSimpleTruncate1() throws IOException, URISyntaxException{
+		Configuration config = new Configuration();
+		config.setInt("fs.glusterfs.timestamp.trim", 1);
+		GlusterVolume fs = new GlusterVolume();
+		fs.initialize(new URI("glusterfs:///"), config);
+		
+		long value1 = 999911111;
+		long trim = fs.trimTimestamp(value1);
+		assertEquals(trim,999911110 );
+		
+	}
+	
+	@Test
+	public void testSimpleTruncate2() throws IOException, URISyntaxException{
+		Configuration config = new Configuration();
+		config.setInt("fs.glusterfs.timestamp.trim", 2);
+		GlusterVolume fs = new GlusterVolume();
+		fs.initialize(new URI("glusterfs:///"), config);
+		
+		long value1 = 999911111;
+		long trim = fs.trimTimestamp(value1);
+		assertEquals(trim,999911100 );
+		
+	}
+	@Test
+	public void testSimpleTruncate3() throws IOException, URISyntaxException{
+		Configuration config = new Configuration();
+		config.setInt("fs.glusterfs.timestamp.trim", 3);
+		GlusterVolume fs = new GlusterVolume();
+		fs.initialize(new URI("glusterfs:///"), config);
+		
+		long value1 = 999911111;
+		long trim = fs.trimTimestamp(value1);
+		assertEquals(trim,999911000 );
+		
+	}
+	
+}


### PR DESCRIPTION
this truncates a specified number of least significant digits from the timestamp.  This is to assist clusters where clock-skew is higher than Hadoop may want.

NTP should still be used, but this will be useful to fine-tune clusters where heavy load cause clock drift.