### PR TITLE
Fix and change pathinfo parser code for gluster stripe volume

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFSPathInfo.java
+++ b/src/main/java/org/apache/hadoop/fs/glusterfs/GlusterFSPathInfo.java
@@ -1,0 +1,263 @@
+/**
+ *
+ * Copyright (c) 2011 Gluster, Inc. <http://www.gluster.com>
+ * This file is part of GlusterFS.
+ *
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package org.apache.hadoop.fs.glusterfs;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.Path;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GlusterFSPathInfo {
+   static final Logger log = LoggerFactory.getLogger(GlusterFSPathInfo.class);
+
+
+   private static ConcurrentMap<String,GlusterFSPathInfo> pathInfoCaches = new ConcurrentHashMap<String,GlusterFSPathInfo>();  // The key is the filename, assuming that the file doesn't change during the execution time.
+
+   private String pathInfo;
+   private long stripeSize;
+   private List<List<String>> locations;
+
+   public static final GlusterFSPathInfo INVALID = new GlusterFSPathInfo("",-1,null);
+
+   public GlusterFSPathInfo(String pathInfo, long stripeSize, List<List<String>> locations) {
+      this.pathInfo = pathInfo;
+      this.stripeSize = stripeSize;
+      this.locations = locations; 
+   } 
+
+   /*
+    * @param pathInfo A string with no leading white spaces
+    * @return The offset of the next subvolume or brick (skip white spaces)
+    */
+   private static int nextStripeOffset(String pathInfo) {
+      int len = pathInfo.length();
+      int endIdx = 0;
+      if (pathInfo.charAt(0) == '<') {
+         endIdx = pathInfo.indexOf('>');
+      } else if (pathInfo.charAt(0) == '(') {
+         int count = 1;
+         for (endIdx=1; endIdx < len; endIdx++) {
+            if (pathInfo.charAt(endIdx) == '(') 
+               count++;
+            else if (pathInfo.charAt(endIdx) == ')')
+               count--;
+            if (count <= 0)
+               break;
+         }
+         if (count != 0) 
+            throw new RuntimeException("Mismatched parenthesis in " + pathInfo);
+      }
+
+      if (endIdx == 0) 
+         throw new RuntimeException("Expected pattern not found " + pathInfo);
+
+      // Skip trailing white spaces
+      for (endIdx++; endIdx < len; endIdx++) {
+         if (!Character.isWhitespace(pathInfo.charAt(endIdx)))
+            break; 
+      }
+
+      return endIdx;
+   }
+
+   /*
+    * @param pathInfo A string starting with '('
+    * @return The string between (excluding) outer parenthesis
+    */
+   private static String getSubVolume(String pathInfo) {
+     int count = 0;
+     int idx=0;
+     for (; idx < pathInfo.length(); idx++) {
+        if (pathInfo.charAt(idx) == '(') 
+           count++;
+        else if (pathInfo.charAt(idx) == ')')
+           count--;
+        if (count <= 0)
+           break;
+     }
+
+     if (count == 0) 
+        return pathInfo.substring(1,idx);
+     else 
+        throw new RuntimeException("Mismatched parenthesis in " + pathInfo);
+   }
+
+   /*
+    * @param pathInfo A glusterfs pathinfo extended attribute
+    * @return A GlusterFSPathInfo
+    */
+   private static GlusterFSPathInfo parse(String pathInfo) {
+      String save = pathInfo;
+  
+      long stripeSize = Long.MAX_VALUE;
+
+      Pattern pathInfoPattern = Pattern.compile("trusted.glusterfs.pathinfo=\"(.+)\"$"); 
+      Pattern dhtPattern = Pattern.compile("^\\(<DISTRIBUTE:[^>]+> (.+)\\)$");
+      Pattern stripePattern = Pattern.compile("^<STRIPE:[^:]+:\\[(\\d+)\\]> (.+)$");
+      Pattern replicatePattern = Pattern.compile("^<REPLICATE:[^>]+> (.+)$"); 
+      Pattern brickPattern = Pattern.compile("<POSIX\\(.*?\\):(.*?):.*?>"); 
+
+      Matcher pathInfoMatcher = pathInfoPattern.matcher(pathInfo);
+      if (pathInfoMatcher.find()) {
+         pathInfo = pathInfoMatcher.group(1);
+      } else {
+         throw new RuntimeException("Cannot find pathinfo attribute");
+      }
+
+      // First level = DHT (exactly once)
+      Matcher dhtMatcher = dhtPattern.matcher(pathInfo);
+      if (dhtMatcher.find()) {
+         pathInfo = dhtMatcher.group(1);
+      }
+
+      // Next level can be nested volume enclosed in ()
+      if (pathInfo.startsWith("(")) {
+         String subVolume = getSubVolume(pathInfo); 
+         if (subVolume.length() != pathInfo.length()-2) 
+            log.warn("Ignore garbage at the end of pathInfo: " + pathInfo.substring(subVolume.length()+2)); // Should not have anything else since DHT must return 1 subvolume
+
+         pathInfo = subVolume;
+      }
+
+      // Check if STRIPE, then find the stripe index 
+      int stripeIndex = 0;
+      int numStripes = 0;
+      List<String> stripes = new ArrayList<String>();
+      Matcher stripeMatcher = stripePattern.matcher(pathInfo);
+      if (stripeMatcher.find()) {
+         stripeSize = Long.parseLong(stripeMatcher.group(1));
+         log.debug("Stripe Size: " + stripeSize);
+         pathInfo = stripeMatcher.group(2);
+
+         while (!pathInfo.isEmpty())  { 
+            int nextOffset = nextStripeOffset(pathInfo);
+            if (pathInfo.charAt(0) == '(') {
+               stripes.add(pathInfo.substring(1,pathInfo.lastIndexOf(')',nextOffset)));
+            } else {
+               stripes.add(pathInfo.substring(0,nextOffset).trim());
+            }
+            pathInfo = pathInfo.substring(nextOffset);
+            numStripes++;
+         }
+
+      } else {
+         numStripes = 1;
+         stripes.add(pathInfo); // Pretending 1 stripe
+      }
+
+      List<List<String>> locations = new ArrayList<List<String>>();
+      for (String stripe: stripes) {
+         // Then, check if REPLICATE 
+         pathInfo = stripe;
+         Matcher replicateMatcher = replicatePattern.matcher(pathInfo);
+         if (replicateMatcher.find()) {
+            pathInfo = replicateMatcher.group(1);
+         }
+
+         // Last level = POSIX (mandatory)
+         Matcher brickMatcher = brickPattern.matcher(pathInfo);
+         List<String> hosts = new ArrayList<String>();
+         while (brickMatcher.find()) {
+            hosts.add(brickMatcher.group(1));
+         }
+         locations.add(hosts);
+      }
+      return new GlusterFSPathInfo(save, stripeSize, locations);
+   }
+
+   /*
+    * @param filename A fuse-mounted filename
+    * @return A GlusterFSPathInfo
+    */
+   public static GlusterFSPathInfo get(String filename) {
+      String cmdOut = new GlusterFSXattr(filename).getPathInfo();
+      return get(filename, cmdOut);
+   }
+
+   /*
+    * @param filename A fuse-mounted filename
+    * @param xattr A gluster pathinfo extended attribute
+    * @return A GlusterFSPathInfo
+    */
+   public static GlusterFSPathInfo get(String filename, String xattr) {
+      GlusterFSPathInfo pathInfo = INVALID;
+      if (!pathInfoCaches.containsKey(filename)) {
+         try {
+            pathInfo = parse(xattr);
+         } catch (Exception e) {
+            log.error("Invalid pathinfo: " + e);
+         }
+         pathInfoCaches.putIfAbsent(filename,pathInfo);
+      }
+      pathInfo = pathInfoCaches.get(filename);
+      return pathInfo; 
+   }
+
+   /*
+    * Clear cache
+    */
+   public static void clear() {
+      pathInfoCaches.clear(); 
+   }
+
+   public String getPathInfo() {
+      return this.pathInfo;
+   }
+
+   public long getStripeSize() {
+      return this.stripeSize;
+   }
+
+   public List<List<String>> getLocations() {
+      return this.locations;
+   }
+
+   public BlockLocation[] getBlockLocations(long start, long len) {
+        long stripeSize = this.stripeSize;                       
+        List<List<String>> locations = this.locations;           
+        if (locations == null) 
+           return null;
+        int numStripes = locations.size();                       
+        int blockStart = (int) (start/stripeSize);               
+        int blockEnd = (int) ((start+len-1)/stripeSize);         
+        int numBlocks = blockEnd-blockStart+1;
+        BlockLocation[] blkLocations = new BlockLocation[numBlocks];
+        for (int i=0; i < numBlocks; i++) {                      
+           long startOffset = (blockStart+i)*stripeSize;         
+           long blockLen = Math.min(stripeSize,start+len-startOffset);         
+           int stripeIndex = ((int) (startOffset / stripeSize)) % numStripes;  
+           String[] hosts = locations.get(stripeIndex).toArray(new String[0]); 
+           String[] names = hosts;                               
+           blkLocations[i] = new BlockLocation(names,hosts,startOffset,blockLen);
+           log.debug("Locate block " + blkLocations[i]);         
+        }                                 
+        return blkLocations;
+   }
+
+}

--- a/src/test/java/org/apache/hadoop/fs/test/TestBlockLocation.java
+++ b/src/test/java/org/apache/hadoop/fs/test/TestBlockLocation.java
@@ -6,8 +6,10 @@ import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.glusterfs.GlusterFSPathInfo;
 import org.apache.hadoop.fs.glusterfs.GlusterFSXattr;
 import org.apache.hadoop.fs.test.connector.HcfsTestConnectorFactory;
 import org.apache.hadoop.fs.test.connector.HcfsTestConnectorInterface;
@@ -16,43 +18,36 @@ import org.junit.Test;
 
 public class TestBlockLocation {
 
-	/*
-	 * Test subclass to simulate / inject xattr values instead of requiring
-	 * filesystem.
-	 * 
-	 */
-	class TestBlockLocationHarnace extends GlusterFSXattr {
-		String xattrValue = null;
+        FileStatus fs = new FileStatus(100000,false,0,0,0,new Path("/a"));
 
-		TestBlockLocationHarnace(String xattrValue) {
-			super(null);
-			this.xattrValue = xattrValue;
-		}
+	@Test
+	public void testDistributedVolume() throws IOException {
+		String xattr = "trusted.glusterfs.pathinfo=\"(<DISTRIBUTE:distributed-dht> <POSIX(/mnt/brick1):vm-2:/mnt/brick1/a>)\"";
 
-		public String execGetFattr() throws IOException {
-			return this.xattrValue;
-		}
+                GlusterFSPathInfo.clear();
+                GlusterFSPathInfo gpi = GlusterFSPathInfo.get(fs.getPath().toString(),xattr);
+		BlockLocation[] blocks = gpi.getBlockLocations(10000, 20000);
+		assertTrue(blocks.length == 1);
+		assertTrue(blocks[0].getHosts()[0].equals("vm-2"));
 	}
 
 	@Test
-	public void testReplicateVolume() throws IOException {
-		String xattr = "trusted.glusterfs.pathinfo=\"(<DISTRIBUTE:StripeVolume-dht> (<STRIPE:StripeVolume-stripe-0:[131072]> <POSIX(/mnt/brick1/stripeVol):vm-1:/mnt/brick1/stripeVol/a>)\"";
-		xattr = xattr.substring(28, xattr.length() - 1);
-		TestBlockLocationHarnace tbl = new TestBlockLocationHarnace(xattr);
+	public void testStripeVolume() throws IOException {
+		String xattr = "trusted.glusterfs.pathinfo=\"(<DISTRIBUTE:StripeVolume-dht> (<STRIPE:StripeVolume-stripe-0:[131072]> <POSIX(/mnt/brick1/stripeVol):vm-1:/mnt/brick1/stripeVol/a>))\"";
 
-		int start = 0;
-		int len = 0;
-		BlockLocation[] blocks = tbl.getPathInfo(start, len);
+                GlusterFSPathInfo.clear();
+                GlusterFSPathInfo gpi = GlusterFSPathInfo.get(fs.getPath().toString(),xattr);
+		BlockLocation[] blocks = gpi.getBlockLocations(0, 10000);
 		assertTrue(blocks.length == 1);
 		assertTrue(blocks[0].getHosts()[0].equals("vm-1"));
 	}
 
 	@Test
-	public void testReplicateVolume2() throws IOException {
+	public void testReplicateVolume() throws IOException {
 		String xattr = "trusted.glusterfs.pathinfo=\"(<DISTRIBUTE:HadoopVol-dht> (<REPLICATE:HadoopVol-replicate-0> <POSIX(/mnt/brick1/HadoopVol):vm-2:/mnt/brick1/HadoopVol/tmp/a> <POSIX(/mnt/brick1/HadoopVol):vm-1:/mnt/brick1/HadoopVol/tmp/a>))\"";
-		xattr = xattr.substring(28, xattr.length() - 1);
-		TestBlockLocationHarnace tbl = new TestBlockLocationHarnace(xattr);
-		BlockLocation[] blocks = tbl.getPathInfo(0, 10000);
+                GlusterFSPathInfo.clear();
+                GlusterFSPathInfo gpi = GlusterFSPathInfo.get(fs.getPath().toString(),xattr);
+                BlockLocation[] blocks = gpi.getBlockLocations(0, 10000);
 		
 		assertTrue(blocks.length == 1);
 		String hosts[] = blocks[0].getHosts();
@@ -65,10 +60,11 @@ public class TestBlockLocation {
 	 * Make sure the xattr code fails gracefull when the input is garbage.
 	 */
 	@Test
-	public void testFailureVolumeGarbage() {
+	public void testFailureVolumeGarbage() throws IOException {
 		String xattr = "dsfsffsfdsf";
-		TestBlockLocationHarnace tbl = new TestBlockLocationHarnace(xattr);
-		BlockLocation[] blocks = tbl.getPathInfo(0, 10000);
+                GlusterFSPathInfo.clear();
+                GlusterFSPathInfo gpi = GlusterFSPathInfo.get(fs.getPath().toString(),xattr);
+                BlockLocation[] blocks = gpi.getBlockLocations(0, 10000);
 		assertNull(blocks);
 	}
 
@@ -77,26 +73,38 @@ public class TestBlockLocation {
 	 */
 
 	@Test
-	public void testFailureVolumeEmpty() {
+	public void testFailureVolumeEmpty() throws IOException {
 		String xattr = "";
-		TestBlockLocationHarnace tbl = new TestBlockLocationHarnace(xattr);
-		BlockLocation[] blocks = tbl.getPathInfo(0, 10000);
+                GlusterFSPathInfo.clear();
+                GlusterFSPathInfo gpi = GlusterFSPathInfo.get(fs.getPath().toString(),xattr);
+                BlockLocation[] blocks = gpi.getBlockLocations(0, 10000);
 		assertNull(blocks);
 	}
 
 	/*
 	 * 
-	 * stripe not yet supported.trusted.pathinfo is incorrect in gluster:
+	 * Require a patch to fix trusted.glusterfs.pathinfo in gluster stripe volume.
 	 * https://bugzilla.redhat.com/show_bug.cgi?id=1200914
 	 */
-
-	public void testStripeVolume() {
-		String xattr = "trusted.glusterfs.pathinfo=\"(<DISTRIBUTE:yuck-dht> (<STRIPE:yuck-stripe-0:[131072]> (<REPLICATE:yuck-replicate-0> <POSIX(/tmp/yuck_brick1):questor:/tmp/yuck_brick1/testfile> <POSIX(/tmp/yuck_brick2):questor:/tmp/yuck_brick2/testfile>)(<REPLICATE:yuck-replicate-1> <POSIX(/tmp/yuck_brick3):questor:/tmp/yuck_brick3/testfile> <POSIX(/tmp/yuck_brick4):questor:/tmp/yuck_brick4/testfile>)(<REPLICATE:yuck-replicate-2> <POSIX(/tmp/yuck_brick5):questor:/tmp/yuck_brick5/testfile> <POSIX(/tmp/yuck_brick6):questor:/tmp/yuck_brick6/testfile>))\"";
+	@Test
+	public void testStripeReplicateVolume() throws IOException {
+		String xattr = "trusted.glusterfs.pathinfo=\"(<DISTRIBUTE:yuck-dht> (<STRIPE:yuck-stripe-0:[131072]> (<REPLICATE:yuck-replicate-0> <POSIX(/tmp/yuck_brick1):vm-1:/tmp/yuck_brick1/testfile> <POSIX(/tmp/yuck_brick2):vm-2:/tmp/yuck_brick2/testfile>)(<REPLICATE:yuck-replicate-1> <POSIX(/tmp/yuck_brick3):vm-3:/tmp/yuck_brick3/testfile> <POSIX(/tmp/yuck_brick4):vm-4:/tmp/yuck_brick4/testfile>)(<REPLICATE:yuck-replicate-2> <POSIX(/tmp/yuck_brick5):vm-5:/tmp/yuck_brick5/testfile> <POSIX(/tmp/yuck_brick6):vm-6:/tmp/yuck_brick6/testfile>)))\"";
 		;
-		xattr = xattr.substring(28, xattr.length() - 1);
-		TestBlockLocationHarnace tbl = new TestBlockLocationHarnace(xattr);
-		BlockLocation[] blocks = tbl.getPathInfo(0, 10000);
-
+                GlusterFSPathInfo.clear();
+                GlusterFSPathInfo gpi = GlusterFSPathInfo.get(fs.getPath().toString(),xattr);
+                BlockLocation[] blocks = gpi.getBlockLocations(200000, 500000);
+		assertTrue(blocks.length == 5);
+		assertTrue(blocks[0].getHosts()[0].equals("vm-3"));
+		assertTrue(blocks[0].getHosts()[1].equals("vm-4"));
+		assertTrue(blocks[1].getHosts()[0].equals("vm-5"));
+		assertTrue(blocks[1].getHosts()[1].equals("vm-6"));
+		assertTrue(blocks[2].getHosts()[0].equals("vm-1"));
+		assertTrue(blocks[2].getHosts()[1].equals("vm-2"));
+		assertTrue(blocks[3].getHosts()[0].equals("vm-3"));
+		assertTrue(blocks[3].getHosts()[1].equals("vm-4"));
+		assertTrue(blocks[4].getHosts()[0].equals("vm-5"));
+		assertTrue(blocks[4].getHosts()[1].equals("vm-6"));
+		
 	}
 
 }


### PR DESCRIPTION
In response to the issue #122 and pathinfo bug https://bugzilla.redhat.com/show_bug.cgi?id=1200914. 
- Updated the pathinfo parser code
- Add and revise TestBlockLocation.java accordingly
- getBlockSize() now returns Gluster stripe block size if available
