### PR TITLE
Updates hadoop-commons and -test to a more recent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.gluster</groupId>
 	<artifactId>glusterfs-hadoop</artifactId>
 	<packaging>jar</packaging>
-	<!-- from now, we will update version manually and ignore maven snapshot 
+	<!-- from now, we will update version manually and ignore maven snapshot
 		features -->
 	<version>2.3.13</version>
 	<name>glusterfs-hadoop</name>
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
-			<version>2.3.0</version>
+			<version>2.7.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-test</artifactId>
-			<version>1.0.0</version>
+			<version>1.2.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -185,43 +185,43 @@
 					<!-- that's the default value -->
 					<dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
 
-					<!-- true is default here, it prints some more information during the 
+					<!-- true is default here, it prints some more information during the
 						build -->
 					<verbose>true</verbose>
 
-					<!-- If you'd like to tell the plugin where your .git directory is, 
-						use this setting, otherwise we'll perform a search trying to figure out the 
+					<!-- If you'd like to tell the plugin where your .git directory is,
+						use this setting, otherwise we'll perform a search trying to figure out the
 						right directory. It's better to add it explicite IMHO. -->
 					<dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
 
 					<!-- ALTERNATE SETUP - GENERATE FILE -->
-					<!-- If you want to keep git information, even in your WAR file etc, 
-						use this mode, which will generate a properties file (with filled out values) 
+					<!-- If you want to keep git information, even in your WAR file etc,
+						use this mode, which will generate a properties file (with filled out values)
 						which you can then normally read using new Properties().load(/**/) -->
 
-					<!-- this is true by default; You may want to set this to false, if 
-						the plugin should run inside a <packaging>pom</packaging> project. Most projects 
-						won't need to override this property. For an use-case for this kind of behaviour 
+					<!-- this is true by default; You may want to set this to false, if
+						the plugin should run inside a <packaging>pom</packaging> project. Most projects
+						won't need to override this property. For an use-case for this kind of behaviour
 						see: https://github.com/ktoso/maven-git-commit-id-plugin/issues/21 -->
 					<skipPoms>true</skipPoms>
 
-					<!-- this is false by default, forces the plugin to generate the git.properties 
+					<!-- this is false by default, forces the plugin to generate the git.properties
 						file -->
 					<generateGitPropertiesFile>true</generateGitPropertiesFile>
 
-					<!-- The path for the to be generated properties file, it's relative 
+					<!-- The path for the to be generated properties file, it's relative
 						to ${project.basedir} -->
 					<generateGitPropertiesFilename>src/main/resources/git.properties</generateGitPropertiesFilename>
 
-					<!-- true by default, controls whether the plugin will fail when no 
+					<!-- true by default, controls whether the plugin will fail when no
 						.git directory is found, when set to false the plugin will just skip execution -->
 					<!-- @since 2.0.4 -->
 					<failOnNoGitDirectory>false</failOnNoGitDirectory>
 
 					<!-- @since 2.1.0 -->
-					<!-- read up about git-describe on the in man, or it's homepage - it's 
-						a really powerful versioning helper and the recommended way to use git-commit-id-plugin. 
-						The configuration bellow is optional, by default describe will run "just 
+					<!-- read up about git-describe on the in man, or it's homepage - it's
+						a really powerful versioning helper and the recommended way to use git-commit-id-plugin.
+						The configuration bellow is optional, by default describe will run "just
 						like git-describe on the command line", even though it's a JGit reimplementation. -->
 					<gitDescribe>
 						<!-- This will show the available tags -->
@@ -229,20 +229,20 @@
 
 						<!-- don't generate the describe property -->
 						<skip>false</skip>
-						<!-- if no tag was found "near" this commit, just print the commit's 
+						<!-- if no tag was found "near" this commit, just print the commit's
 							id instead, helpful when you always expect this field to be not-empty -->
 						<always>false</always>
-						<!-- how many chars should be displayed as the commit object id? 7 
-							is git's default, 0 has a special meaning (see end of this README.md), and 
+						<!-- how many chars should be displayed as the commit object id? 7
+							is git's default, 0 has a special meaning (see end of this README.md), and
 							40 is the maximum value here -->
 						<abbrev>7</abbrev>
 
-						<!-- when the build is triggered while the repo is in "dirty state", 
+						<!-- when the build is triggered while the repo is in "dirty state",
 							append this suffix -->
 						<dirty>-dirty</dirty>
 
-						<!-- always print using the "tag-commits_from_tag-g_commit_id-maybe_dirty" 
-							format, even if "on" a tag. The distance will always be 0 if you're "on" 
+						<!-- always print using the "tag-commits_from_tag-g_commit_id-maybe_dirty"
+							format, even if "on" a tag. The distance will always be 0 if you're "on"
 							the tag. -->
 						<forceLongFormat>false</forceLongFormat>
 					</gitDescribe>


### PR DESCRIPTION
Drops transitive dependency on commons-collections:3.2.1.  See
https://github.com/Alluxio/alluxio/pull/3405 and
http://www.geekinasuit.com/2016/03/apache-commons-collections-321.html.
